### PR TITLE
Remove TLS v1 support

### DIFF
--- a/start_vsftpd.sh
+++ b/start_vsftpd.sh
@@ -69,7 +69,7 @@ if [ ! -z "$ADDRESS" ]; then
 fi
 
 if [ ! -z "$TLS_CERT" ] || [ ! -z "$TLS_KEY" ]; then
-  TLS_OPT="-orsa_cert_file=$TLS_CERT -orsa_private_key_file=$TLS_KEY -ossl_enable=YES -oallow_anon_ssl=NO -oforce_local_data_ssl=YES -oforce_local_logins_ssl=YES -ossl_tlsv1=YES -ossl_sslv2=NO -ossl_sslv3=NO -ossl_ciphers=HIGH"
+  TLS_OPT="-orsa_cert_file=$TLS_CERT -orsa_private_key_file=$TLS_KEY -ossl_enable=YES -oallow_anon_ssl=NO -oforce_local_data_ssl=YES -oforce_local_logins_ssl=YES -ossl_tlsv1=NO -ossl_sslv2=NO -ossl_sslv3=NO -ossl_ciphers=HIGH"
 fi
 
 # Used to run custom commands inside container


### PR DESCRIPTION
Deprecating TLS v1 via [rfc8996](https://datatracker.ietf.org/doc/html/rfc8996).